### PR TITLE
[Refactor] : 토큰 처리 변경

### DIFF
--- a/src/main/java/kdt/web_ide/common/exception/ErrorCode.java
+++ b/src/main/java/kdt/web_ide/common/exception/ErrorCode.java
@@ -20,18 +20,18 @@ public enum ErrorCode {
   INVALID_LOGINID(HttpStatus.NOT_FOUND, "ACCOUNT-009", "유효하지 않은 아이디입니다."),
   INVALID_IMAGE(HttpStatus.BAD_REQUEST, "ACCOUNT-010", "유효하지 않은 이미지입니다."),
   INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "ACCOUNT-011", "유효하지 않은 이미지입니다."),
+  KAKAO_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "ACCOUNT-0012", "유효하지 않은 토큰입니다."),
 
   // 채팅방
-
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-008", "채팅방을 찾을 수 없습니다."),
 
   // 게시판
-
   MEMBER_ALREADY_IN_BOARD(HttpStatus.BAD_REQUEST, "BOARD-001", "이미 게시판에 초대된 멤버입니다."),
   NO_PERMISSION(HttpStatus.UNAUTHORIZED, "BOARD-002", "권한이 없습니다."),
   BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD-003", "존재하지 않는 게시판입니다."),
   MEMBER_NOT_IN_BOARD(HttpStatus.NOT_FOUND, "BOARD-004", "게시판에 존재하지 않는 멤버입니다."),
   INVALID_TITLE(HttpStatus.BAD_REQUEST, "BOARD-005", "제목 입력은 필수입니다."),
+
   // S3
   S3_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "S3-001", "S3 업로드 실패"),
   FILE_EXECUTION_ERROR(HttpStatus.BAD_REQUEST, "S3-002", "파일 실행 실패"),

--- a/src/main/java/kdt/web_ide/members/controller/MemberController.java
+++ b/src/main/java/kdt/web_ide/members/controller/MemberController.java
@@ -1,9 +1,14 @@
 package kdt.web_ide.members.controller;
 
 import java.io.IOException;
+import java.time.Duration;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -12,10 +17,11 @@ import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kdt.web_ide.members.dto.request.TestSignUpRequest;
+import kdt.web_ide.members.dto.response.LoginResponseWithToken;
 import kdt.web_ide.members.dto.response.MemberResponse;
+import kdt.web_ide.members.dto.response.RefreshResponseDto;
 import kdt.web_ide.members.dto.response.TokenResponse;
 import kdt.web_ide.members.kakao.KakaoLoginParams;
-import kdt.web_ide.members.kakao.KakaoReissueParams;
 import kdt.web_ide.members.service.CustomUserDetails;
 import kdt.web_ide.members.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -28,25 +34,45 @@ public class MemberController {
 
   private final MemberService memberService;
 
-  @Operation(summary = "임시 회원가입 API", description = "임시 회원가입")
-  @PostMapping("/testjoin")
-  public ResponseEntity<?> testSignUp(@RequestBody TestSignUpRequest request) {
-    memberService.testSignUp(request);
-    return ResponseEntity.status(HttpStatus.OK)
-        .body("아이디 : " + request.email() + " 비밀번호 : " + request.password());
-  }
-
   @Operation(summary = "임시 로그인 API", description = "임시 로그인")
   @PostMapping("/testlogin")
   public ResponseEntity<?> testLogin(@RequestBody TestSignUpRequest request) {
-    return ResponseEntity.status(HttpStatus.OK).body(memberService.testLogin(request));
+
+    LoginResponseWithToken response = memberService.testLogin(request);
+
+    ResponseCookie refreshTokenCookie =
+        ResponseCookie.from("refreshToken", response.refreshToken())
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofDays(7))
+            .build();
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .header("Set-Cookie", refreshTokenCookie.toString())
+        .body(response.responseDto());
   }
 
   // 로그인
   @Operation(summary = "카카오 로그인/회원가입 API", description = "카카오 로그인/회원가입")
   @PostMapping("/login")
   public ResponseEntity<?> login(@RequestBody KakaoLoginParams params) {
-    return ResponseEntity.status(HttpStatus.OK).body(memberService.login(params));
+
+    LoginResponseWithToken response = memberService.login(params);
+
+    ResponseCookie refreshTokenCookie =
+        ResponseCookie.from("refreshToken", response.refreshToken())
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofDays(7))
+            .build();
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .header("Set-Cookie", refreshTokenCookie.toString())
+        .body(response.responseDto());
   }
 
   // 회원 정보 조회
@@ -81,7 +107,30 @@ public class MemberController {
 
   @Operation(summary = "엑세스 토큰 재발급 API")
   @PostMapping("/refresh")
-  public ResponseEntity<TokenResponse> recreateAccessToken(@RequestBody KakaoReissueParams params) {
-    return ResponseEntity.status(HttpStatus.OK).body(memberService.reissue(params));
+  public ResponseEntity<TokenResponse> recreateAccessToken(
+      HttpServletRequest request, HttpServletResponse response) {
+
+    RefreshResponseDto responseDto = memberService.refresh(request, response);
+
+    ResponseCookie refreshTokenCookie =
+        ResponseCookie.from("refreshToken", responseDto.refreshToken())
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofDays(7))
+            .build();
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .header("Set-Cookie", refreshTokenCookie.toString())
+        .body(new TokenResponse(responseDto.accessToken()));
+  }
+
+  @Operation(summary = "카카오 엑세스 토큰 재발급 API")
+  @GetMapping("/kakao")
+  public ResponseEntity<TokenResponse> getKakaoAccessToken(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(memberService.getKakaoAccessToken(userDetails.getMember().getMemberId()));
   }
 }

--- a/src/main/java/kdt/web_ide/members/dto/response/LoginResponseWithToken.java
+++ b/src/main/java/kdt/web_ide/members/dto/response/LoginResponseWithToken.java
@@ -1,0 +1,3 @@
+package kdt.web_ide.members.dto.response;
+
+public record LoginResponseWithToken(LoginResponseDto responseDto, String refreshToken) {}

--- a/src/main/java/kdt/web_ide/members/dto/response/RefreshResponseDto.java
+++ b/src/main/java/kdt/web_ide/members/dto/response/RefreshResponseDto.java
@@ -1,0 +1,3 @@
+package kdt.web_ide.members.dto.response;
+
+public record RefreshResponseDto(String accessToken, String refreshToken) {}

--- a/src/main/java/kdt/web_ide/members/dto/response/TokenResponse.java
+++ b/src/main/java/kdt/web_ide/members/dto/response/TokenResponse.java
@@ -7,5 +7,4 @@ import lombok.Getter;
 @Getter
 public class TokenResponse {
   String accessToken;
-  String refreshToken;
 }

--- a/src/main/java/kdt/web_ide/members/entity/Member.java
+++ b/src/main/java/kdt/web_ide/members/entity/Member.java
@@ -34,6 +34,10 @@ public class Member extends BaseTimeEntity {
   @Column(name = "refresh_token")
   private String refreshToken;
 
+  @Setter
+  @Column(name = "kakao_refresh_token")
+  private String kakaoRefreshToken;
+
   @Column(name = "identification_code")
   private String identificationCode;
 

--- a/src/main/java/kdt/web_ide/members/kakao/KakaoApiClient.java
+++ b/src/main/java/kdt/web_ide/members/kakao/KakaoApiClient.java
@@ -18,7 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KakaoApiClient implements OAuthApiClient {
 
-  private static final String GRANT_TYPE = "authorization_code";
+  private static final String LOGIN_GRANT_TYPE = "authorization_code";
+  private static final String REFRESH_GRANT_TYPE = "refresh_token";
 
   @Value("${oauth.kakao.url.auth}")
   private String authUrl;
@@ -35,7 +36,7 @@ public class KakaoApiClient implements OAuthApiClient {
   private final RestTemplate restTemplate;
 
   @Override
-  public String requestAccessToken(OAuthLoginParams params) {
+  public KakaoToken requestAccessToken(OAuthLoginParams params) {
 
     String url = authUrl + "/oauth/token";
 
@@ -44,7 +45,7 @@ public class KakaoApiClient implements OAuthApiClient {
         MediaType.valueOf("application/x-www-form-urlencoded;charset=utf-8"));
 
     MultiValueMap<String, String> body = params.makeBody();
-    body.add("grant_type", GRANT_TYPE);
+    body.add("grant_type", LOGIN_GRANT_TYPE);
     body.add("client_id", clientId);
     body.add("client_secret", clientSecret);
 
@@ -54,7 +55,7 @@ public class KakaoApiClient implements OAuthApiClient {
 
     assert response != null;
 
-    return response.getAccessToken();
+    return response;
   }
 
   @Override
@@ -74,14 +75,14 @@ public class KakaoApiClient implements OAuthApiClient {
   }
 
   @Override
-  public String reissueAccessToken(KakaoReissueParams params) {
+  public KakaoToken reissueAccessToken(KakaoReissueParams params) {
     String url = authUrl + "/oauth/token";
 
     HttpHeaders httpHeaders = new HttpHeaders();
     httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
     MultiValueMap<String, String> body = params.makeBody();
-    body.add("grant_type", GRANT_TYPE);
+    body.add("grant_type", REFRESH_GRANT_TYPE);
     body.add("client_id", clientId);
     body.add("client_secret", clientSecret);
 
@@ -91,6 +92,6 @@ public class KakaoApiClient implements OAuthApiClient {
 
     assert response != null;
 
-    return response.getAccessToken();
+    return response;
   }
 }

--- a/src/main/java/kdt/web_ide/members/kakao/KakaoReissueParams.java
+++ b/src/main/java/kdt/web_ide/members/kakao/KakaoReissueParams.java
@@ -3,11 +3,13 @@ package kdt.web_ide.members.kakao;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class KakaoReissueParams {
 
   private String refreshToken;

--- a/src/main/java/kdt/web_ide/members/oAuth/OAuthApiClient.java
+++ b/src/main/java/kdt/web_ide/members/oAuth/OAuthApiClient.java
@@ -1,12 +1,13 @@
 package kdt.web_ide.members.oAuth;
 
 import kdt.web_ide.members.kakao.KakaoReissueParams;
+import kdt.web_ide.members.kakao.KakaoToken;
 
 public interface OAuthApiClient {
 
-  String requestAccessToken(OAuthLoginParams params);
+  KakaoToken requestAccessToken(OAuthLoginParams params);
 
-  String reissueAccessToken(KakaoReissueParams params);
+  KakaoToken reissueAccessToken(KakaoReissueParams params);
 
   OAuthInfoResponse requestOauthInfo(String accessToken);
 }

--- a/src/main/java/kdt/web_ide/members/oAuth/RequestOAuthInfoService.java
+++ b/src/main/java/kdt/web_ide/members/oAuth/RequestOAuthInfoService.java
@@ -3,6 +3,7 @@ package kdt.web_ide.members.oAuth;
 import org.springframework.stereotype.Component;
 
 import kdt.web_ide.members.kakao.KakaoReissueParams;
+import kdt.web_ide.members.kakao.KakaoToken;
 
 @Component
 public class RequestOAuthInfoService {
@@ -13,13 +14,15 @@ public class RequestOAuthInfoService {
     this.client = client;
   }
 
-  public OAuthInfoResponse request(OAuthLoginParams params) {
-    String accessToken = client.requestAccessToken(params);
+  public OAuthInfoResponse request(String accessToken) {
     return client.requestOauthInfo(accessToken);
   }
 
-  public OAuthInfoResponse reissue(KakaoReissueParams params) {
-    String accessToken = client.reissueAccessToken(params);
-    return client.requestOauthInfo(accessToken);
+  public KakaoToken login(OAuthLoginParams params) {
+    return client.requestAccessToken(params);
+  }
+
+  public KakaoToken reissue(KakaoReissueParams params) {
+    return client.reissueAccessToken(params);
   }
 }


### PR DESCRIPTION
> pr title: commit message #이슈번호

## #️⃣ 연관된 이슈

> close #56 



## 📋 작업 내용

카카오 톡 캘린더를 이용하기 때문에 카카오의 access/refresh, 저희 자체 access/refresh 총 4개의 토큰을 관리합니다

자체 access는 클라이언트가
카카오 access는 서버 메모리에
자체 refresh와 카카오 refresh는 DB에 저장하며
자체 refresh의 경우 쿠키를 통해 전달됩니다.



## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
